### PR TITLE
Configure tox to run the tests.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,5 @@ omit =
     *tests/*,
     *urls.py,
     *wsgi.py,
-    manage.py
+    manage.py,
+    .tox/*,

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 .coverage
 .pytest_cache
+.tox
 
 #sqlite db
 db.sqlite3

--- a/.licenses_strategy.ini
+++ b/.licenses_strategy.ini
@@ -1,0 +1,17 @@
+[Licenses]
+authorized_licenses:
+        bsd
+        new bsd
+        simplified bsd
+        apache
+        apache 2.0
+        apache software
+        gnu lgpl
+        gpl v2
+        gpl v3
+        lgpl with exceptions or zpl
+        isc
+        isc license (iscl)
+        mit
+        python software foundation
+        zpl 2.1

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ You can run the tests with the following command.
 ```
 $ py.test
 ```
+
+You can also run all the checks (linting, format and licenses) that are validated by the CI pipeline using the tox command.
+
+```
+$ tox
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 pytest-django
 mixer
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist = lint, format, py36, licenses
+skipsdist = True
+
+[testenv]
+deps =
+    -rrequirements-dev.txt
+commands =
+    pytest
+
+[testenv:lint]
+deps =
+    flake8 > 3.0
+commands =
+    python3 -m flake8 {posargs}
+
+[testenv:format]
+deps =
+    black
+commands =
+    python3 -m black --check --line-length=100 {posargs:.}
+
+[testenv:licenses]
+deps =
+    -rrequirements-dev.txt
+    liccheck
+commands =
+    liccheck -s .licenses_strategy.ini -l PARANOID -r requirements.txt
+
+[flake8]
+show-source = True
+max-line-length = 100
+ignore = E203,W503
+exclude = .git,.tox,dist,*egg,.venv,manage.py,*settings.py


### PR DESCRIPTION
This commits configures tox to run the tests
It also configures the linting, formating and
licencing checks this is aimed to be used by
the CI pipeline.

Signed-off-by: Clement Verna <cverna@tutanota.com>