### PR TITLE
Add views, router and versioning

### DIFF
--- a/fpdc/releases/admin.py
+++ b/fpdc/releases/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
+from fpdc.releases.models import ReleaseType
+
 # Register your models here.
+admin.site.register(ReleaseType)

--- a/fpdc/releases/serializers.py
+++ b/fpdc/releases/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
+from fpdc.releases.models import ReleaseType
+
+
+class ReleaseTypeSerializer(ModelSerializer):
+    class Meta:
+        model = ReleaseType
+        fields = "__all__"

--- a/fpdc/releases/tests/test_serializers.py
+++ b/fpdc/releases/tests/test_serializers.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from fpdc.releases.serializers import ReleaseTypeSerializer
+from mixer.backend.django import mixer
+
+
+class ReleaseTypeSerializerTests(TestCase):
+    def test_serialize(self):
+        release_type = mixer.blend("releases.ReleaseType")
+        serializer = ReleaseTypeSerializer(release_type)
+        assert serializer.data["short"] == release_type.short
+        assert serializer.data["name"] == release_type.name
+        assert serializer.data["suffix"] == release_type.suffix
+
+    def test_deserialize_invalid(self):
+        serializer = ReleaseTypeSerializer(data={"name": None, "short": "short-name"})
+        assert serializer.is_valid() is False

--- a/fpdc/releases/tests/test_views.py
+++ b/fpdc/releases/tests/test_views.py
@@ -1,0 +1,56 @@
+from mixer.backend.django import mixer
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from fpdc.releases.models import ReleaseType
+
+
+class ReleaseTypeViewTests(APITestCase):
+    def test_create_release_type(self):
+        url = reverse("v1:releasetype-list")
+        data = {"name": "Release", "short": "ga", "suffix": ""}
+        response = self.client.post(url, data, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert ReleaseType.objects.count() == 1
+        assert ReleaseType.objects.get().name == "Release"
+
+    def test_update_release_type(self):
+        release_type = mixer.blend(ReleaseType)
+        url = reverse("v1:releasetype-detail", kwargs={"pk": release_type.pk})
+        data = {"name": "Release", "short": release_type.short, "suffix": release_type.suffix}
+        response = self.client.put(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert ReleaseType.objects.count() == 1
+        assert ReleaseType.objects.get().name == "Release"
+
+    def test_partial_update_release_type(self):
+        release_type = mixer.blend(ReleaseType)
+        url = reverse("v1:releasetype-detail", kwargs={"pk": release_type.pk})
+        data = {"name": "Release"}
+        response = self.client.patch(url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert ReleaseType.objects.count() == 1
+        assert ReleaseType.objects.get().name == "Release"
+
+    def test_delete_release_type(self):
+        release_type = mixer.blend(ReleaseType)
+        url = reverse("v1:releasetype-detail", kwargs={"pk": release_type.pk})
+        assert ReleaseType.objects.count() == 1
+        response = self.client.delete(url, format="json")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert ReleaseType.objects.count() == 0
+
+    def test_get_release_type(self):
+        release_type = mixer.blend(ReleaseType)
+        url = reverse("v1:releasetype-detail", kwargs={"pk": release_type.pk})
+        response = self.client.get(url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == release_type.name
+
+    def test_get_release_type_list(self):
+        mixer.cycle(5).blend(ReleaseType)
+        url = reverse("v1:releasetype-list")
+        response = self.client.get(url, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert ReleaseType.objects.count() == 5

--- a/fpdc/releases/views.py
+++ b/fpdc/releases/views.py
@@ -1,3 +1,9 @@
-from django.shortcuts import render
+from rest_framework import viewsets
 
-# Create your views here.
+from fpdc.releases.models import ReleaseType
+from fpdc.releases.serializers import ReleaseTypeSerializer
+
+
+class ReleaseTypeViewSet(viewsets.ModelViewSet):
+    queryset = ReleaseType.objects.all()
+    serializer_class = ReleaseTypeSerializer

--- a/fpdc/releases/views.py
+++ b/fpdc/releases/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets
+from rest_framework import filters
 
 from fpdc.releases.models import ReleaseType
 from fpdc.releases.serializers import ReleaseTypeSerializer
@@ -7,3 +8,6 @@ from fpdc.releases.serializers import ReleaseTypeSerializer
 class ReleaseTypeViewSet(viewsets.ModelViewSet):
     queryset = ReleaseType.objects.all()
     serializer_class = ReleaseTypeSerializer
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = "__all__"
+    ordering = ("id",)

--- a/fpdc/settings/base.py
+++ b/fpdc/settings/base.py
@@ -95,9 +95,7 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-    },
+    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},

--- a/fpdc/settings/base.py
+++ b/fpdc/settings/base.py
@@ -76,6 +76,7 @@ WSGI_APPLICATION = "fpdc.wsgi.application"
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
 }
 
 
@@ -94,12 +95,18 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
-    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
+    },
     {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
+# Authentication backends
+# https://docs.djangoproject.com/en/1.11/ref/settings/#authentication-backends
+
+AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/fpdc/urls.py
+++ b/fpdc/urls.py
@@ -13,7 +13,17 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib import admin
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = [url(r"^admin/", admin.site.urls)]
+from fpdc.releases.views import ReleaseTypeViewSet
+
+router = DefaultRouter(trailing_slash=False)
+
+router.register(r"releasetype", ReleaseTypeViewSet)
+
+urlpatterns = [
+    url(r"^admin/", admin.site.urls),
+    url(r"^api/v1/", include(router.urls, namespace="v1")),
+]

--- a/fpdc/urls.py
+++ b/fpdc/urls.py
@@ -25,5 +25,5 @@ router.register(r"releasetype", ReleaseTypeViewSet)
 
 urlpatterns = [
     url(r"^admin/", admin.site.urls),
-    url(r"^api/v1/", include(router.urls, namespace="v1")),
+    url(r"^api/v1/", include((router.urls, "releases"), namespace="v1")),
 ]


### PR DESCRIPTION
* Creates a serializer for `ReleaseType` that will (de)serialize Models to JSON
* Creates a ModelViewSet for ReleaseType
* Register ReleaseType with admin site
* Set default versioning class to Namespace
* Adds ModelBackend to AUTHENTICATION_BACKENDS for local user testing
* Create a Default Router, register the ReleaseType viewset and include the router urls under an 'api/v1' prefix