### PR TITLE
Fix settings module

### DIFF
--- a/fpdc/releases/migrations/0001_create_release_type.py
+++ b/fpdc/releases/migrations/0001_create_release_type.py
@@ -9,17 +9,21 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='ReleaseType',
+            name="ReleaseType",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('short', models.CharField(max_length=255, unique=True)),
-                ('name', models.CharField(max_length=255, unique=True)),
-                ('suffix', models.CharField(blank=True, max_length=255, unique=True)),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("short", models.CharField(max_length=255, unique=True)),
+                ("name", models.CharField(max_length=255, unique=True)),
+                ("suffix", models.CharField(blank=True, max_length=255, unique=True)),
             ],
-        ),
+        )
     ]

--- a/fpdc/wsgi.py
+++ b/fpdc/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fpdc.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fpdc.settings.base")
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fpdc.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fpdc.settings.base")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands =
 deps =
     black
 commands =
-    python3 -m black --check --line-length=100 {posargs:.}
+    python3 -m black --check {posargs:.}
 
 [testenv:licenses]
 deps =


### PR DESCRIPTION
The settings module has been converted to a directory, update the paths in `manage.py` and `wsgi.py`.

Also, configure Black using the config file rather than the command line options in `tox.ini` so that independant runs of the `black` command line use the same options.
And reformat one migration file that made the test fail.