### PR TITLE
Enable OIDC authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ db.sqlite3
 
 #VS Code
 .vscode
+
+#local runtime settings
+.env

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,6 +21,20 @@ First upgrade pip and then install the dependencies
 (.venv) $ pip install -r requirements-dev.txt
 ```
 
+Get a client ID and secret, if you don't already have one.
+
+```
+(.venv) $ curl --request POST --header "Content-Type: application/json" --data '{"redirect_uris": ["http://localhost:8000/oidc/callback/"], "application_type": "native", "token_endpoint_auth_method": "client_secret_post"}' https://iddev.fedorainfracloud.org/openidc/Registration
+```
+
+Extract the client ID and secret received from the provider above and export them into the virtual
+environment:
+
+```
+(.venv) $ export OIDC_RP_CLIENT_ID=...
+(.venv) $ export OIDC_RP_CLIENT_SECRET=...
+```
+
 ### docker-compose environment
 
 A docker-compose environment is available to give access to a development environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   web:
     build: .
     command: /code/run-container.sh
+    env_file: .env
     environment:
       - DJANGO_SETTINGS_MODULE=fpdc.settings.base
       - PYTHONPATH=/code

--- a/fpdc/settings/base.py
+++ b/fpdc/settings/base.py
@@ -25,7 +25,7 @@ SECRET_KEY = "change-this-in-production"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["localhost"]
 
 
 # Application definition
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "computed_property",
     # fpdc apps
     "fpdc.releases",
+    "mozilla_django_oidc",
 ]
 
 MIDDLEWARE = [
@@ -82,6 +83,7 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 10,
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
+    "DEFAULT_AUTHENTICATION_CLASSES": ["mozilla_django_oidc.contrib.drf.OIDCAuthentication"],
 }
 
 
@@ -112,7 +114,23 @@ AUTH_PASSWORD_VALIDATORS = [
 # Authentication backends
 # https://docs.djangoproject.com/en/1.11/ref/settings/#authentication-backends
 
-AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.ModelBackend",
+    "mozilla_django_oidc.auth.OIDCAuthenticationBackend",
+]
+
+# OIDC Settings
+OIDC_RP_SIGN_ALGO = "RS256"
+OIDC_RP_IDP_SIGN_KEY = "-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQEAq/0/XjILQxF3OaQZtFE3wVJ5UUuxZbxiJ/z+Zai0EOHiaMMxVyoo\nibDRen615r525DQ8TmQyR0eMQEpQ6SUvaOunahpYohgAkbkYggUMQhcoCLme18ZJ\nBTNWTP8w4t7mcuZd1cy1KtHpEvH4gkrjp8N3vIv1lzFraSc+p2rHMbV+AX5CJQ1H\nohBdwaqyOBKp0nzY27gu2EH2vzCwXkO4zGtrHfjjGc0Ra4WG+xz1AWg833xcFj3p\nqM3vca09jDLBme+GT151LcCCXRNyOZPZ3ZX62NxkMyqvVJHC3Uu2Q1hSHO7f6AZk\nZXY88PXXEH52T2ZrWiISowjTcGUboP8goQIDAQAB\n-----END RSA PUBLIC KEY-----\n"
+OIDC_RP_CLIENT_ID = os.getenv("OIDC_RP_CLIENT_ID")
+OIDC_RP_CLIENT_SECRET = os.getenv("OIDC_RP_CLIENT_SECRET")
+OIDC_OP_AUTHORIZATION_ENDPOINT = "https://iddev.fedorainfracloud.org/openidc/Authorization"
+OIDC_OP_TOKEN_ENDPOINT = "https://iddev.fedorainfracloud.org/openidc/Token"
+OIDC_OP_USER_ENDPOINT = "https://iddev.fedorainfracloud.org/openidc/UserInfo"
+LOGIN_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL_FAILURE = "/error"
+OIDC_RP_SCOPES = "openid profile email"
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/fpdc/urls.py
+++ b/fpdc/urls.py
@@ -25,5 +25,6 @@ router.register(r"release", ReleaseViewSet)
 
 urlpatterns = [
     url(r"^admin/", admin.site.urls),
+    url(r"^oidc/", include("mozilla_django_oidc.urls")),
     url(r"^api/v1/", include((router.urls, "releases"), namespace="v1")),
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-django
 mixer
 tox
 freezegun
+flask-oidc

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary
 django-computed-property
 gunicorn
 whitenoise
+mozilla-django-oidc == 1.1.2


### PR DESCRIPTION
This PR enables OpenID authentication against `iddev.fedorainfracloud.org` using the `mozilla-django-oidc` package. 

## Test ##

First, you must generate a client ID/secret by registering as an application `iddev` as the provider. This can easily be done by using the `oidc-register` utility found in the `flask-oidc` package. However, until [puiterwijk/flask-oidc#63](https://github.com/puiterwijk/flask-oidc/pull/63) is accepted and merged, you will need to register with the provider manually using `curl`:

```
curl --request POST --header "Content-Type: application/json" --data '{"redirect_uris": ["http://localhost:8000/oidc/callback/"], "application_type": "native", "token_endpoint_auth_method": "client_secret_post"}' https://iddev.fedorainfracloud.org/openidc/Registration
```

Then run a local server (`python manage.py runserver`) with the generated client ID and secret set in the `OIDC_RP_CLIENT_ID` and `OIDC_RP_CLIENT_SECRET` environment variables, respectively.

## Note ##

There is no main page yet, so the login redirect URL of "/" results in an HTTP 404 error. This is normal.

- [x] Add documentation changes to `DEVELOPING.md`
- [x] Make changes to `docker-compose` to set client ID and secret during container run time

---

fixes #8