### PR TITLE
Use oidc-register module instead of flask-oidc

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest-django
 mixer
 tox
 freezegun
-flask-oidc
+oidc-register


### PR DESCRIPTION
Signed-off-by: Clement Verna <cverna@tutanota.com>