### PR TITLE
Add custom OIDC authentication backend.

### DIFF
--- a/examples/create_release.py
+++ b/examples/create_release.py
@@ -10,7 +10,7 @@ oidc = openidc_client.OpenIDCClient(
     os.getenv("OIDC_RP_CLIENT_SECRET"),
 )
 
-scopes = ["openid", "profile", "email", "https://fpdc.fedoraproject.org/oidc/create-release"]
+scopes = ["openid", "profile", "email", "https://id.fedoraproject.org/scope/groups"]
 
 url = "http://localhost:8000/api/v1/release"
 

--- a/fpdc/oidc_backend.py
+++ b/fpdc/oidc_backend.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from django.contrib.auth.models import Group
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class FpdcOIDCAuthenticationBackend(OIDCAuthenticationBackend):
+    def create_user(self, claims):
+        """
+        Custom create_user method that sync the FAS releng-team member
+        with the internal FPDC releng-group.
+        """
+        user = super(FpdcOIDCAuthenticationBackend, self).create_user(claims)
+
+        if settings.FAS_GROUP in claims.get("groups", ""):
+            releng_group, created = Group.objects.get_or_create(name="releng-team")
+            releng_group.user_set.add(user)
+
+        return user

--- a/fpdc/settings/base.py
+++ b/fpdc/settings/base.py
@@ -115,10 +115,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Authentication backends
 # https://docs.djangoproject.com/en/1.11/ref/settings/#authentication-backends
 
-AUTHENTICATION_BACKENDS = [
-    "django.contrib.auth.backends.ModelBackend",
-    "mozilla_django_oidc.auth.OIDCAuthenticationBackend",
-]
+AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.ModelBackend"]
 
 # OIDC Settings
 OIDC_RP_SIGN_ALGO = "RS256"
@@ -132,6 +129,8 @@ LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_REDIRECT_URL_FAILURE = "/error"
 OIDC_RP_SCOPES = "openid profile email"
+OIDC_DRF_AUTH_BACKEND = "fpdc.oidc_backend.FpdcOIDCAuthenticationBackend"
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
@@ -162,3 +161,8 @@ LOGGING = {
         "django": {"handlers": ["console"], "level": os.getenv("DJANGO_LOG_LEVEL", "DEBUG")}
     },
 }
+
+# FPDC Settings
+
+# FAS group that give permission to create add and delete resources
+FAS_GROUP = "releng-team"


### PR DESCRIPTION
We want to store know if an authenticated user is a member
of the releng-team FAS group. This will later be used to check
permissions.

Signed-off-by: Clement Verna <cverna@tutanota.com>