### PR TITLE
Make it possible to filter for active releases.

### DIFF
--- a/fpdc/releases/views.py
+++ b/fpdc/releases/views.py
@@ -11,3 +11,15 @@ class ReleaseViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.OrderingFilter,)
     ordering_fields = "__all__"
     ordering = ("-version",)  # Descending ordering on version higher version first.
+
+    def get_queryset(self):
+        """
+        Optionally restricts the returned Release to only active releases,
+        by filtering against a `active` query parameter in the URL.
+        """
+        queryset = Release.objects.all()
+        active = self.request.query_params.get("active", None)
+        if active is not None:
+            queryset = queryset.filter(active=active.title())
+
+        return queryset


### PR DESCRIPTION
This commit adds the possibility to use a query parameter in the url
to filter active releases. for example `?active=true`  or `?active=false`.

Signed-off-by: Clement Verna <cverna@tutanota.com>