### PR TITLE
Add complexity check during the CI.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,19 @@ instructions to configure your editor to run it on the files you edit.
 
 Note : The max line length is configured to be 100.
 
+### Code Complexity
+
+We use [radon](https://radon.readthedocs.io/en/latest/index.html) to check the code complexy of the application.
+We aim for fpdc to stay withing the A-C [rank of complexity](https://radon.readthedocs.io/en/latest/commandline.html#the-cc-command) and this is
+enforced by the CI pipeline.
+
+When making a change to the code base you can run radon manually:
+
+```
+(.venv) pip install radon
+(.venv) radon cc fpdc/ -e *.sqlite3,*.pyc
+```
+
 ### Tests
 
 The test suites can be run using [tox](http://tox.readthedocs.io/) by simply

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ passenv = HOME
 [testenv:lint]
 deps =
     flake8 > 3.0
+    radon
 commands =
     python3 -m flake8 {posargs}
 
@@ -40,6 +41,7 @@ commands =
     bandit -r fpdc/ -x fpdc/releases/tests/ -ll
 
 [flake8]
+radon-max-cc = 20
 show-source = True
 max-line-length = 100
 ignore = E203,W503


### PR DESCRIPTION
radon allows to check for the code complexity of the application.
This commit enforce during the CI to stay at a moderate level of complexity

Signed-off-by: Clement Verna <cverna@tutanota.com>